### PR TITLE
make length const variables public for ML-DSA-87

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,9 +409,12 @@ pub mod ml_dsa_87 {
     const ETA: i32 = 2;
     const BETA: i32 = TAU * ETA;
     const OMEGA: i32 = 75;
-    const SK_LEN: usize = 4896;
-    const PK_LEN: usize = 2592;
-    const SIG_LEN: usize = 4627;
+    /// Private (secret) key length in bytes.
+    pub const SK_LEN: usize = 4896;
+    /// Public key length in bytes.
+    pub const PK_LEN: usize = 2592;
+    /// Signature length in bytes.
+    pub const SIG_LEN: usize = 4627;
 
     functionality!();
 }


### PR DESCRIPTION
Hi Maintainer(s),

I found that the length variables of ML-DSA-87 is private so that crate users cannot use them directly.
Here's the commit to fix that problem.

Thanks.